### PR TITLE
Multistage build to create an image for running the webapp 54MB compressed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: generic
+services: docker
+
+before_script:
+  - docker build -t $DOCKER_TAG .
+
+script:
+  - docker run -d -p 3000:3000 --name ytdl $DOCKER_TAG
+  - sleep 10; ./test/e2e.js
+
+deploy:
+  provider: script
+  script: docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD && docker push $DOCKER_TAG
+  on:
+    branch: master

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,14 +20,11 @@ RUN apk add --update --no-cache \
     rm /usr/lib/python*/pydoc.py                        && \
     rm -rf /root/.cache /var/cache /usr/share/terminfo  && \
     ln /usr/bin/python3.6 /usr/bin/python               && \
+    npm install -g npm@latest                           && \
+    npm cache clean --force                             && \
     mkdir -p public/temp
 
-# install the latest npm and clear the cache
-RUN npm install -g npm@latest && \
-    npm cache clean --force
-
 COPY package.json package-lock.json ./
-
 
 FROM base as dev
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-M alpine:3.8 as base
+FROM alpine:3.8 as base
 
 WORKDIR /home/app
 EXPOSE 3000
@@ -53,4 +53,3 @@ COPY --from=dev /home/app/public ./public
 
 # copy over the source code
 COPY ./src ./src
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # python 3.7 and node 8 LTS
-FROM austinpray/python-node:3.7-8
+FROM austinpray/python-node:3.7-8 as dev
 
 WORKDIR /home/app
 EXPOSE 3000
@@ -17,3 +17,40 @@ RUN npm ci
 COPY . ./
 RUN mkdir -p public/temp \
     && npm run build
+
+FROM alpine:3.8 as prod
+
+WORKDIR /home/app
+EXPOSE 3000
+CMD [ "npm", "start" ]
+
+RUN apk add --update --no-cache \
+        python3 \
+        ffmpeg \
+        nodejs \
+        nodejs-npm \
+        ca-certificates && \
+    find / -type d -name __pycache__ -exec rm -r {} +   && \
+    rm -r /usr/lib/python*/ensurepip                    && \
+    rm -r /usr/lib/python*/lib2to3                      && \
+    rm -r /usr/lib/python*/turtledemo                   && \
+    rm /usr/lib/python*/turtle.py                       && \
+    rm /usr/lib/python*/webbrowser.py                   && \
+    rm /usr/lib/python*/doctest.py                      && \
+    rm /usr/lib/python*/pydoc.py                        && \
+    rm -rf /root/.cache /var/cache /usr/share/terminfo  && \
+    ln /usr/bin/python3.6 /usr/bin/python               && \
+    mkdir -p public/temp
+
+# install the latest npm and only the production/non-dev dependencies
+COPY package.json package-lock.json ./
+RUN npm install -g npm@latest && npm ci --only=production && npm cache clean --force
+
+# copy over the source code
+COPY src ./src
+
+# copy the frontend build over from the dev stage
+COPY --from=dev /home/app/public ./public
+
+# run node server
+CMD ["npm", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,19 @@
-#
-# Dockerfile for ytdl-webserver
-#
-FROM ubuntu:16.04
+# python 3.7 and node 8 LTS
+FROM austinpray/python-node:3.7-8
 
 WORKDIR /home/app
+EXPOSE 3000
+CMD [ "npm", "start" ]
 
 RUN apt-get update \
-    && apt-get install -y curl ffmpeg \
-    && curl -sL https://deb.nodesource.com/setup_6.x | bash - \
-    && apt-get install -y nodejs \
-    && npm install -g npm@latest \
-    && rm -rf /var/lib/apt/lists/*
-
-# This is on a separate line because youtube-dl needs to be frequently updated
-RUN apt-get update \
-    && apt-get install -y youtube-dl \
+    && apt-get install -y ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 
 # only install node_modules if the package.json changes
+# youtube-dl is installed via node-youtube-dl dep
 COPY package.json package-lock.json ./
 RUN npm ci
 
 COPY . ./
 RUN mkdir -p public/temp \
     && npm run build
-
-EXPOSE 3000
-CMD [ "npm", "start" ]

--- a/test/e2e.js
+++ b/test/e2e.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+
+const http = require('http');
+const querystring = require('querystring');
+
+const postData = querystring.stringify({
+  'url': 'https://www.youtube.com/watch?v=qNf9nzvnd1k'
+});
+
+const req = http.request(
+  {
+    host: 'localhost',
+    port: '3000',
+    path: '/download',
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'Content-Length': Buffer.byteLength(postData)
+    }
+  },
+  (res) => {
+    const { statusCode } = res;
+    res.on('data', (chunk) => {
+      console.log(`BODY: ${chunk}`);
+    });
+    res.on('end', () => {
+      console.log('No more data in response.');
+      if (statusCode !== 200) {
+        console.log(`got status ${statusCode}`);
+        process.exit(1);
+      }
+      console.log('yay it works')
+    });
+  }
+).on('error', (e) => {
+  console.error(`Got error: ${e.message}`);
+  process.exit(1);
+});
+
+req.write(postData);
+req.end();


### PR DESCRIPTION
Based on: https://github.com/Algram/ytdl-webserver/pull/6 (so merge after that one if you want it I suppose).

Adds a multistage build, meaning that the image that runs the webapp is 54MB compressed as opposed to 500MB. The dev dependencies, caches and some other bloat are not in the final image in this one.

You can still build the dev image using:
```
docker build --target dev -t mauritso/ytdl-webserver-dev .
```

run only image using:
```
docker build -t mauritso/ytdl-webserver .
```

on the docker hub [here](https://hub.docker.com/r/mauritso/ytdl-webserver/tags/)

you can  try the image using:
```
docker run -p 3000:3000 mauritso/ytdl-webserver
```
