### PR TITLE
 Modify Dockerfile for Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,15 @@
-FROM node:dubnium-stretch-slim
+FROM alpine:latest
 
-WORKDIR /home/app
+RUN apk update \
+    && apk add youtube-dl curl ffmpeg nodejs npm python \
+    && rm -rf /var/cache/apk/*
 
-RUN apt update \
-    && apt install -y curl ffmpeg \
-    && rm -rf /var/lib/apt/lists/*
-
-# This is on a separate line because youtube-dl needs to be frequently updated
-RUN apt update \
-    && apt install -y youtube-dl \
-    && rm -rf /var/lib/apt/lists/*
-
-# Only install node_modules if the package.json changes
 COPY package.json package-lock.json ./
-RUN npm ci
+RUN npm install
 
-COPY . ./
-RUN mkdir -p public/temp \
-    && npm run build
+COPY . .
+
+CMD npm start
 
 EXPOSE 3000
-CMD [ "npm", "start" ]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,12 @@
-FROM alpine:latest
+FROM alpine:3.11
 
 RUN apk update \
-    && apk add youtube-dl curl ffmpeg nodejs npm python \
+    && apk add curl ffmpeg nodejs npm python \
+    && rm -rf /var/cache/apk/*
+
+# This is on a separate line because youtube-dl needs to be frequently updated
+RUN apk update \
+    && apk add youtube-dl \
     && rm -rf /var/cache/apk/*
 
 COPY package.json package-lock.json ./
@@ -9,6 +14,5 @@ RUN npm install
 
 COPY . .
 
-CMD npm start
-
 EXPOSE 3000
+CMD npm start

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,3 @@ COPY . .
 CMD npm start
 
 EXPOSE 3000
-


### PR DESCRIPTION
Using Alpine as Base Image reduces the image's size from 666MB to 309MB.