### PR TITLE
Improve Dockerfile to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,12 @@ FROM node:dubnium-stretch-slim
 WORKDIR /home/app
 
 RUN apt update \
-    && apt install -y curl ffmpeg \
+    && apt install --no-install-recommends -y curl ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 
 # This is on a separate line because youtube-dl needs to be frequently updated
 RUN apt update \
-    && apt install -y youtube-dl \
+    && apt install --no-install-recommends -y youtube-dl \
     && rm -rf /var/lib/apt/lists/*
 
 # Only install node_modules if the package.json changes


### PR DESCRIPTION
Hi there,

Thanks for maintaining ytdl-webserver. I've made a small improvement to the Dockerfile that I think could help optimize the image size.

Summary of Changes:
* Using the `--no-install-recommends` flag with apt-get install in a Dockerfile helps save layer space, improve build times, and reduce the size and attack surface of the final image, as well as prevent hidden dependencies.


Impact on the image size:
* Image size before repair: 634.72 MB
* Image size after repair: 429.27 MB
* Difference: 205.45 MB (32.37%)

Thanks,